### PR TITLE
fix home-manager deprecations

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -158,7 +158,7 @@ in
           utility.safeOps = true;
         };
 
-        initExtraFirst = ''
+        initContent = lib.mkBefore ''
           ${lib.strings.optionalString config.autoTmux ''
             [[ -o interactive ]] && [[ -z $NO_TMUX ]] && tmuxp-default
           ''}
@@ -350,12 +350,12 @@ in
 
       services.ssh-agent.enable = pkgs.hostPlatform.isLinux;
 
-      services.gpg-agent = {
-        enable = pkgs.hostPlatform.isLinux;
-        defaultCacheTtl = 259200;
-        defaultCacheTtlSsh = 259200;
-        pinentryPackage = pkgs.pinentry-curses;
-      };
+        services.gpg-agent = {
+          enable = pkgs.hostPlatform.isLinux;
+          defaultCacheTtl = 259200;
+          defaultCacheTtlSsh = 259200;
+          pinentry.package = pkgs.pinentry-curses;
+        };
 
       # You can also manage environment variables but you will have to manually
       # source


### PR DESCRIPTION
## Summary
- update zsh init config for newer Home Manager
- switch gpg-agent pinentry option to new attribute name

## Testing
- `nix --version` *(fails: command not found)*
- `home-manager --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689226840014832e8142f57f9a4fbae3