### PR TITLE
Configure Vim Python host early to include requests

### DIFF
--- a/modules/editing.nix
+++ b/modules/editing.nix
@@ -467,6 +467,9 @@ in
           vim-wordmotion
         ] ++ lib.optional config.vim-ollama.enable vim-ollama;
         extraConfig = ''
+          let g:python3_host_prog = "${vimPythonEnv}/bin/python3"
+          let $PYTHONPATH = "${vimPythonEnv}/lib/python3.12/site-packages"
+
           set encoding=utf-8
 
           set nobackup
@@ -645,8 +648,6 @@ in
           autocmd FileType ledger setlocal commentstring=;\ %s
           autocmd FileType cabal setlocal foldmethod=indent
 
-          let g:python3_host_prog = "${vimPythonEnv}/bin/python3"
-          let $PYTHONPATH = "${vimPythonEnv}/lib/python3.12/site-packages"
         '';
       };
   };


### PR DESCRIPTION
## Summary
- initialize Vim's Python host with a custom environment containing `requests` before plugin startup

## Testing
- `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893722a51f4832e8ae8ae00aae10f39