### PR TITLE
Configure Vim Python host early to include requests

### DIFF
--- a/modules/editing.nix
+++ b/modules/editing.nix
@@ -1,6 +1,7 @@
 { config, pkgs, lib, ... }:
 let
   vimPythonEnv = pkgs.python3.withPackages (ps: with ps; [ requests httpx jinja2 ]);
+  vimPythonPath = "${vimPythonEnv}/${pkgs.python3.sitePackages}";
   util = (import ./util.nix) { inherit pkgs; };
   simplePlugin = name: body: pkgs.vimUtils.buildVimPlugin {
     inherit name;
@@ -467,6 +468,9 @@ in
           vim-wordmotion
         ] ++ lib.optional config.vim-ollama.enable vim-ollama;
         extraConfig = ''
+          let g:python3_host_prog = "${vimPythonEnv}/bin/python3"
+          let $PYTHONPATH = "${vimPythonPath}"
+
           set encoding=utf-8
 
           set nobackup
@@ -645,8 +649,6 @@ in
           autocmd FileType ledger setlocal commentstring=;\ %s
           autocmd FileType cabal setlocal foldmethod=indent
 
-          let g:python3_host_prog = "${vimPythonEnv}/bin/python3"
-          let $PYTHONPATH = "${vimPythonEnv}/lib/python3.12/site-packages"
         '';
       };
   };


### PR DESCRIPTION
## Summary
- initialize Vim's Python host with a custom environment containing `requests` before plugin startup
- derive Python site-packages path dynamically so Vim can find `requests`

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893722a51f4832e8ae8ae00aae10f39