### PR TITLE
Migrate git/delta settings to new Home Manager options and update hostPlatform references

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -224,52 +224,56 @@ in
 
       programs.git = {
         enable = true;
-        userName = config.user;
-        userEmail = config.email;
         lfs.enable = true;
         signing = {
           key = config.gpgSignKey;
           signByDefault = config.gpgSignKey != null;
         };
-        aliases = {
-          st = "status";
-          lg = "log --oneline --abbrev-commit --all --graph --decorate --color";
-          sha = "rev-parse HEAD";
-          last = "log -1 HEAD --stat";
-          commit-now = "!git commit -m $(date --iso-8601=seconds)";
-        };
-        delta = {
-          enable = true;
-          options = {
-            navigate = true;
-            light = false;
-            dark = true;
-            side-by-side = false;
-            line-numbers = true;
-            features = "zebra-dark";
-            # this isn't in the RTP for some reason so we clone it from
-            # https://github.com/dandavison/delta/blob/main/themes.gitconfig
-            zebra-dark = {
-              minus-style = "syntax \"#330f0f\"";
-              minus-emph-style = "syntax \"#4f1917\"";
-              plus-style = "syntax \"#0e2f19\"";
-              plus-emph-style = "syntax \"#174525\"";
-              map-styles = ''
-                bold purple => syntax "#330f29",
-                bold blue => syntax "#271344",
-                bold cyan => syntax "#0d3531",
-                bold yellow => syntax "#222f14"
-              '';
-              zero-style = "syntax";
-              whitespace-error-style = "#aaaaaa";
-            };
+        settings = {
+          user = {
+            name = config.user;
+            email = config.email;
           };
-        };
-        extraConfig = {
+          alias = {
+            st = "status";
+            lg = "log --oneline --abbrev-commit --all --graph --decorate --color";
+            sha = "rev-parse HEAD";
+            last = "log -1 HEAD --stat";
+            commit-now = "!git commit -m $(date --iso-8601=seconds)";
+          };
           init.defaultBranch = "main";
           core.editor = "vim";
           merge.conflictstyle = "diff3";
           diff.colorMoved = "default";
+        };
+      };
+
+      programs.delta = {
+        enable = true;
+        enableGitIntegration = true;
+        options = {
+          navigate = true;
+          light = false;
+          dark = true;
+          side-by-side = false;
+          line-numbers = true;
+          features = "zebra-dark";
+          # this isn't in the RTP for some reason so we clone it from
+          # https://github.com/dandavison/delta/blob/main/themes.gitconfig
+          zebra-dark = {
+            minus-style = "syntax \"#330f0f\"";
+            minus-emph-style = "syntax \"#4f1917\"";
+            plus-style = "syntax \"#0e2f19\"";
+            plus-emph-style = "syntax \"#174525\"";
+            map-styles = ''
+              bold purple => syntax "#330f29",
+              bold blue => syntax "#271344",
+              bold cyan => syntax "#0d3531",
+              bold yellow => syntax "#222f14"
+            '';
+            zero-style = "syntax";
+            whitespace-error-style = "#aaaaaa";
+          };
         };
       };
 
@@ -349,10 +353,10 @@ in
       };
       programs.starship.enable = true;
 
-      services.ssh-agent.enable = pkgs.hostPlatform.isLinux;
+      services.ssh-agent.enable = pkgs.stdenv.hostPlatform.isLinux;
 
         services.gpg-agent = {
-          enable = pkgs.hostPlatform.isLinux;
+          enable = pkgs.stdenv.hostPlatform.isLinux;
           defaultCacheTtl = 259200;
           defaultCacheTtlSsh = 259200;
           pinentry.package = pkgs.pinentry-curses;


### PR DESCRIPTION
### Motivation

- Address deprecation warnings by migrating legacy `programs.git` options to the new `programs.git.settings` structure.
- Move `delta` configuration out of `programs.git.delta` into top-level `programs.delta` and explicitly enable Git integration to satisfy newer Home Manager expectations.
- Replace references to the renamed platform check `pkgs.hostPlatform` with `pkgs.stdenv.hostPlatform`.

### Description

- Reworked `programs.git` block in `modules/base.nix` to use `settings.user.name`, `settings.user.email`, `settings.alias`, and other `settings.*` keys instead of the old `userName`, `userEmail`, `aliases`, and `extraConfig` fields.
- Extracted the previous `delta` configuration into a new `programs.delta` block and set `enableGitIntegration = true` while preserving the `options` and `zebra-dark` theme settings.
- Updated platform checks from `pkgs.hostPlatform.isLinux` to `pkgs.stdenv.hostPlatform.isLinux` for `services.ssh-agent` and `services.gpg-agent`.
- Changed only `modules/base.nix` (42 insertions, 38 deletions) to implement these updates.

### Testing

- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cc3a30f0832e9dda13cd10d4fa8c)